### PR TITLE
Update Vietnamese translations for AI and tools

### DIFF
--- a/src/lang/vi/ai.json
+++ b/src/lang/vi/ai.json
@@ -46,11 +46,11 @@
   "brewNotInstall": "Không phát hiện thấy Homebrew trên hệ thống của bạn, nếu bạn muốn cài đặt nó, bạn có thể nhấp vào liên kết này\n<a href=\"javascript:void();\" onclick=\"openUrl('https://flyenv.com/guide/getting-started.html#pre-launch-preparation')\">https://flyenv.com/guide/getting-started.html#pre-launch-preparation</a>\nLàm theo tài liệu để cài đặt.\n",
   "brewHasInstall": "Phát hiện Homebrew đã được cài đặt trên hệ thống.\nNếu bạn gặp sự cố khi cài đặt hoặc gỡ cài đặt phần mềm từ bên trong ứng dụng, bạn có thể thử thực hiện các lệnh theo cách thủ công từ dòng lệnh",
   "mysqlPassword": "Mật khẩu tài khoản ban đầu cho cơ sở dữ liệu MySQL/MariaDB là root root\nChương trình không có công cụ quản lý dữ liệu cơ sở dữ liệu, nếu bạn cần thay đổi mật khẩu hoặc quản lý dữ liệu cơ sở dữ liệu, bạn có thể sử dụng cách sau:\nphpMyAdmin <a href=\"javascript:void();\" onclick=\"openUrl('https://www.phpmyadmin.net/')\">https://www.phpmyadmin.net/</a>\nNavicat <a href=\"javascript:void();\" onclick=\"openUrl('https://www.navicat.com/')\">https://www.navicat.com.cn/</a>\nMySQL Workbench <a href=\"javascript:void();\" onclick=\"openUrl('https://www.mysql.com/products/workbench/')\">https://www.mysql.com/products/workbench/</a>\nDataGrip <a href=\"javascript:void();\" onclick=\"openUrl('https://www.jetbrains.com/datagrip/')\">https://www.jetbrains.com/zh-cn/datagrip/</a>\nDbGate <a href=\"javascript:void();\" onclick=\"openUrl('https://dbgate.org/')\">https://dbgate.org/</a>\nDBeaver <a href=\"javascript:void();\" onclick=\"openUrl('https://dbeaver.io/')\">https://dbeaver.io/</a>\nNếu có bất kỳ công cụ nào khác mà bạn nghĩ là tốt, vui lòng liên hệ với tôi để thêm chúng.",
-  "AIPartner": "Đối tác AI",
-  "PartnerName": "Tên đối tác",
-  "PartnerPrompt": "Lời nhắc đối tác",
-  "NeedPartnerName": "Vui lòng nhập Tên đối tác",
-  "NeedPartnerPrompt": "Vui lòng nhập Lời nhắc đối tác",
+  "AIPartner": "Trợ lý AI",
+  "PartnerName": "Tên trợ lý",
+  "PartnerPrompt": "Lời nhắc trợ lý",
+  "NeedPartnerName": "Vui lòng nhập Tên trợ lý",
+  "NeedPartnerPrompt": "Vui lòng nhập Lời nhắc trợ lý",
   "saveAsCustom": "Lưu làm Tùy chỉnh",
   "Temperature": "Nhiệt độ",
   "Meticulous": "Tỉ mỉ",
@@ -67,5 +67,5 @@
   "enterTips": "[Enter] gửi, [Shift+Enter] xuống dòng, [Ctrl+Enter] gửi không tạo",
   "noLiencesTips": "Hiện tại không có giấy phép, bạn có thể dùng thử trong ba ngày",
   "alert": "Cảnh báo",
-  "customer": "Copilots của tôi"
+  "customer": "Trợ lý của tôi"
 }

--- a/src/lang/vi/tools.json
+++ b/src/lang/vi/tools.json
@@ -52,5 +52,8 @@
   "NameNeed": "Vui lòng nhập tên",
   "CodeLanguageNeed": "Vui lòng chọn ngôn ngữ lập trình",
   "BatchOperations": "Thao tác hàng loạt",
-  "SelectAll": "Chọn tất cả"
+  "SelectAll": "Chọn tất cả",
+  "MoveToTop": "Di chuyển lên đầu",
+  "MoveToGroup": "Di chuyển vào nhóm",
+  "MarkdownPreview": "Xem trước Markdown"
 }


### PR DESCRIPTION
Revised AI-related terms in vi/ai.json to use 'Trợ lý' instead of 'Đối tác', and updated 'Copilots của tôi' to 'Trợ lý của tôi'. Added new tool-related translations in vi/tools.json for moving items and Markdown preview.