### PR TITLE
Update Vietnamese translations for Podman configuration options

### DIFF
--- a/src/lang/en/podman.json
+++ b/src/lang/en/podman.json
@@ -50,5 +50,20 @@
   "CustomInput": "Custom input",
   "SelectPresetModule": "Select a preset module",
   "TagPlaceholder": "latest or a version number, e.g. 8.2, 5.7, 16-alpine",
-  "NamePlaceholder": "e.g. nginx"
+  "NamePlaceholder": "e.g. nginx",
+  "ComposeFileSaveDir": "Compose file save directory",
+  "DockerImageMirror": "Docker image mirror (optional)",
+  "Persistence": "Data persistence",
+  "MYSQL_ROOT_PASSWORD": "ROOT password",
+  "MYSQL_DATABASE": "Database name",
+  "MYSQL_USER": "Database user",
+  "MYSQL_PASSWORD": "Database password",
+  "PortBind": "Port mapping",
+  "ContainerPort": "Container port",
+  "LocalPort": "Host port",
+  "ComposeNameErrorTips": "Project name must start with a letter or number, and may include lowercase letters, numbers, underscores (_) or hyphens (-).",
+  "Rename": "Rename",
+  "ImageName": "Image name",
+  "CommandArgs": "Command arguments",
+  "Volumes": "Volume mounts"
 }

--- a/src/lang/vi/podman.json
+++ b/src/lang/vi/podman.json
@@ -50,5 +50,20 @@
   "CustomInput": "Tự nhập",
   "SelectPresetModule": "Chọn mô-đun dựng sẵn",
   "TagPlaceholder": "latest hoặc số phiên bản, ví dụ: 8.2, 5.7, 16-alpine",
-  "NamePlaceholder": "ví dụ: nginx"
+  "NamePlaceholder": "ví dụ: nginx",
+  "ComposeFileSaveDir": "Thư mục lưu tệp Compose",
+  "DockerImageMirror": "Nguồn mirror Docker image (tùy chọn)",
+  "Persistence": "Lưu trữ dữ liệu bền vững",
+  "MYSQL_ROOT_PASSWORD": "Mật khẩu ROOT",
+  "MYSQL_DATABASE": "Tên cơ sở dữ liệu",
+  "MYSQL_USER": "Tài khoản truy cập cơ sở dữ liệu",
+  "MYSQL_PASSWORD": "Mật khẩu cơ sở dữ liệu",
+  "PortBind": "Ánh xạ cổng",
+  "ContainerPort": "Cổng trong container",
+  "LocalPort": "Cổng trên máy host",
+  "ComposeNameErrorTips": "Tên dự án phải bắt đầu bằng chữ cái hoặc số, và chỉ được chứa chữ thường, số, dấu gạch dưới (_) hoặc dấu gạch ngang (-).",
+  "Rename": "Đổi tên",
+  "ImageName": "Tên image",
+  "CommandArgs": "Tham số lệnh",
+  "Volumes": "Gắn kết volume"
 }


### PR DESCRIPTION
This pull request updates the English and Vietnamese localization files for Podman, adding several new translation keys to support additional features and UI elements. The changes ensure that new options and error tips in the Podman interface are properly localized.

Localization enhancements:

* Added new translation keys for Compose file save directory, Docker image mirror, persistence, and volume mounts to both `src/lang/en/podman.json` and `src/lang/vi/podman.json` for improved feature coverage. [[1]](diffhunk://#diff-de74ffb634b27f1b180cb1b969e91a48c09d77d93d3d4f83fb0181e8a2b9f6dbL53-R68) [[2]](diffhunk://#diff-a610461cee5d93adc4fa14d66b42bf93c012ff22ad04e9a17e2818cf159f1f26L53-R68)
* Included database-related terms such as `MYSQL_ROOT_PASSWORD`, `MYSQL_DATABASE`, `MYSQL_USER`, and `MYSQL_PASSWORD` to support environment variable configuration in both languages. [[1]](diffhunk://#diff-de74ffb634b27f1b180cb1b969e91a48c09d77d93d3d4f83fb0181e8a2b9f6dbL53-R68) [[2]](diffhunk://#diff-a610461cee5d93adc4fa14d66b42bf93c012ff22ad04e9a17e2818cf159f1f26L53-R68)
* Added keys for port mapping (`PortBind`, `ContainerPort`, `LocalPort`) and command arguments to enhance container configuration options. [[1]](diffhunk://#diff-de74ffb634b27f1b180cb1b969e91a48c09d77d93d3d4f83fb0181e8a2b9f6dbL53-R68) [[2]](diffhunk://#diff-a610461cee5d93adc4fa14d66b42bf93c012ff22ad04e9a17e2818cf159f1f26L53-R68)
* Provided a new error tip for compose project naming rules under `ComposeNameErrorTips` to help users avoid invalid names. [[1]](diffhunk://#diff-de74ffb634b27f1b180cb1b969e91a48c09d77d93d3d4f83fb0181e8a2b9f6dbL53-R68) [[2]](diffhunk://#diff-a610461cee5d93adc4fa14d66b42bf93c012ff22ad04e9a17e2818cf159f1f26L53-R68)
* Added translations for UI actions like `Rename` and identifiers such as `ImageName` to both language files. [[1]](diffhunk://#diff-de74ffb634b27f1b180cb1b969e91a48c09d77d93d3d4f83fb0181e8a2b9f6dbL53-R68) [[2]](diffhunk://#diff-a610461cee5d93adc4fa14d66b42bf93c012ff22ad04e9a17e2818cf159f1f26L53-R68)